### PR TITLE
Autoconnect preparation (supercedes #1)

### DIFF
--- a/inkwell/inkwell.html
+++ b/inkwell/inkwell.html
@@ -10,7 +10,20 @@
 <body>
   <div id="inkwell-bottle"></div>
   <script id="storyweave-script">
-  const autoSignaling = {};
+  const autoSignaling = {
+    makeLocalId: function (id) {
+      document.getElementById("storyweaver-storage-view").contentWindow.postMessage({ action: 'fallback_signal', key: "id", value: id }, storageUrlPrefix + storageHost);
+    },
+    makeSdpReciever: function (sdpr) {
+      document.getElementById("storyweaver-storage-view").contentWindow.postMessage({ action: 'fallback_signal', key: "reciever_sdp", value: sdpr }, storageUrlPrefix + storageHost);
+    },
+    makeSdpSender: function (sender) {
+      document.getElementById("storyweaver-storage-view").contentWindow.postMessage({ action: 'fallback_signal', key: "sender_sdp", value: sender }, storageUrlPrefix + storageHost);
+    },
+    makeManualSignal: function (signal) {
+      document.getElementById("storyweaver-storage-view").contentWindow.postMessage({ action: 'fallback_signal', key: "manual_signal", value: signal }, storageUrlPrefix + storageHost);
+    }
+  };
   function checkForParticipatingDiv() {
     return document.getElementById('inkwell-bottle') !== null;
   }
@@ -62,11 +75,11 @@
         //let the page embedding this script handle the logic
         //we just listen for their responses with an eventlistener
         const signalingEvent = new CustomEvent('signalingMessage', { detail: value });
-        window.parent.dispatchEvent(signalingEvent);
+        window.dispatchEvent(signalingEvent);
       }
     });
   
-    window.addEventListener('signalingMessage', (event) => {
+    window.addEventListener('signalingBackendMessage', (event) => {
       const message = event.detail;
       //console.log('Received signaling message:', message);
       window.parent.postMessage({ action: "backend_signal", value: message }, window.parent.origin);
@@ -185,7 +198,6 @@
             </div>
           </div>
                   <div id="button-container" style="width: 100%; display: flex; justify-content: space-around;">
-                      <button class="tipholder" id="autoSignaling-button">T</button>
                       <button class="tipholder" id="top-story"> ^ <span class="tooltip-text">Go to the first page in this story</span></button>
                       <button class="tipholder" id="back-story"> < <span class="tooltip-text">Go to the previous page in this story</span></button>
                       <button class="tipholder" id="pos-tag"> + <span class="tooltip-text">Add or promote tags on this page, creating a new story, or adding this page to an existing story</span></button>
@@ -236,6 +248,9 @@
       } else if (action === 'resume') {
   
         resumeConnectionsAndStoredOffers(value.attemptResume, value.stored_offers);
+      } else if (action === 'backend_signal') {
+
+        routeSignalingMessage(value)
       }
     });
   
@@ -243,11 +258,6 @@
       let clickType = e.target.id;
       e.target.classList.add("sheen-effect");
       switch (clickType) {
-        case 'autoSignaling-button':
-          setTimeout(function() {
-            console.log("autoSignaling object :", autoSignaling);
-          }, 0);
-          break
         case 'top-story':
         case 'back-story':
         case 'fwd-story':
@@ -322,7 +332,6 @@
         case 'manual-router':
           let signalInput = document.getElementById("manual-router");
           try {
-            autoSignaling.sdpManual = outeSignalingMessage(JSON.parse(signalInput.value));
             routeSignalingMessage(JSON.parse(signalInput.value));
           } catch (e) {
             console.info(e);
@@ -348,8 +357,7 @@
     function generatePeerId() {
       let id = Math.random().toString(36).slice(2, 18);
       document.getElementById("peer-id").innerText = id;
-      autoSignaling.id = id;
-      document.getElementById("storyweaver-storage-view").contentWindow.postMessage({ action: 'fallback_signal', key: "id", value: autoSignaling.id }, storageUrlPrefix + storageHost);
+      autoSignaling.makeLocalId(id);
       return id;
     }
 
@@ -361,8 +369,7 @@
             document.getElementById("other-offer").disabled = true;
             document.getElementById("other-offer").value = "";
             document.getElementById("local-answer").innerText = maybeAnswer;
-            autoSignaling.sdpReciever = maybeAnswer;
-            document.getElementById("storyweaver-storage-view").contentWindow.postMessage({ action: 'fallback_signal', key: "reciever_sdp", value: autoSignaling.sdpReciever }, storageUrlPrefix + storageHost);
+            autoSignaling.makeSdpReciever(maybeAnswer);
             document.getElementById('network-status').innerText = "Please provide answer to other peer...";
           }, 0);
         }
@@ -377,8 +384,7 @@
         let pc = createRTCPeerConnection(peerId);
         let offer = await createOffer(pc, peerId);
         setTimeout(function() {
-          autoSignaling.sdpSender = offer;
-          document.getElementById("storyweaver-storage-view").contentWindow.postMessage({ action: 'fallback_signal', key: "sender_sdp", value: autoSignaling.sdpSender }, storageUrlPrefix + storageHost);
+          autoSignaling.makeSdpSender(offer);
           document.getElementById("spare-offer").innerText = offer;
           document.getElementById('network-status').innerText = "Please provide offer to other peer...";
         }, 0);
@@ -589,8 +595,7 @@
         }));
       } else if (message.to == document.getElementById("other-peer").value) {
         // Manual signalling, stored in UI
-        autoSignaling.manualSignal += JSON.stringify(message);
-        document.getElementById("storyweaver-storage-view").contentWindow.postMessage({ action: 'fallback_signal', key: "manual_signal", value: autoSignaling.manualSignal }, storageUrlPrefix + storageHost);
+        autoSignaling.makeManualSignal(JSON.stringify(message));
         document.getElementById("manual-signals").innerText += JSON.stringify(message);
       } else if (connectedPeers[message.to]) {
         connectedPeers[message.to].channel.send(JSON.stringify(message.inner));

--- a/inkwell/inkwell.html
+++ b/inkwell/inkwell.html
@@ -10,6 +10,7 @@
 <body>
   <div id="inkwell-bottle"></div>
   <script id="storyweave-script">
+  const Jem = {};
   function checkForParticipatingDiv() {
     return document.getElementById('inkwell-bottle') !== null;
   }
@@ -34,7 +35,7 @@
       // need to think of a better way to secure requests.
   
       const { action, key, value } = event.data;
-      console.log(event.data);
+      //console.log(event.data);
       if (action === 'set') {
         localStorage.setItem(key, JSON.stringify(value));
       } else if (action === 'get') {
@@ -67,7 +68,7 @@
   
     window.addEventListener('signalingMessage', (event) => {
       const message = event.detail;
-      console.log('Received signaling message:', message);
+      //console.log('Received signaling message:', message);
       window.parent.postMessage({ action: "backend_signal", value: message }, window.parent.origin);
     });
   
@@ -184,11 +185,12 @@
             </div>
           </div>
                   <div id="button-container" style="width: 100%; display: flex; justify-content: space-around;">
-            <button class="tipholder" id="top-story"> ^ <span class="tooltip-text">Go to the first page in this story</span></button>
+                      <button class="tipholder" id="jem-button">T</button>
+                      <button class="tipholder" id="top-story"> ^ <span class="tooltip-text">Go to the first page in this story</span></button>
                       <button class="tipholder" id="back-story"> < <span class="tooltip-text">Go to the previous page in this story</span></button>
                       <button class="tipholder" id="pos-tag"> + <span class="tooltip-text">Add or promote tags on this page, creating a new story, or adding this page to an existing story</span></button>
                       <button class="tipholder" id="neg-tag"> - <span class="tooltip-text">Remove or demote tags on this page</span></button>
-            <button class="tipholder" id="report"> !! <span class="tooltip-text">Report abuse!</span></button>
+                      <button class="tipholder" id="report"> !! <span class="tooltip-text">Report abuse!</span></button>
                       <button class="tipholder" id="pos-usr"> + U <span class="tooltip-text">Promote the user(s) that submitted/promoted this page</span></button>
                       <button class="tipholder" id="neg-usr"> - U <span class="tooltip-text">Demote the user(s) that submitted/promoted this page</span></button>
                       <button class="tipholder" id="fwd-story"> > <span class="tooltip-text">Go to the next page in this story</span></button>
@@ -230,7 +232,7 @@
   
       if (action === 'response') {
         // Handle the received data from the iframe's localstorage
-        console.log(`Received data for key "${key}":`, value);
+        //console.log(`Received data for key "${key}":`, value);
       } else if (action === 'resume') {
   
         resumeConnectionsAndStoredOffers(value.attemptResume, value.stored_offers);
@@ -241,6 +243,11 @@
       let clickType = e.target.id;
       e.target.classList.add("sheen-effect");
       switch (clickType) {
+        case 'jem-button':
+          setTimeout(function() {
+            console.log("Jem object :", Jem);
+          }, 0);
+          break
         case 'top-story':
         case 'back-story':
         case 'fwd-story':
@@ -315,6 +322,7 @@
         case 'manual-router':
           let signalInput = document.getElementById("manual-router");
           try {
+            Jem.sdpManual = outeSignalingMessage(JSON.parse(signalInput.value));
             routeSignalingMessage(JSON.parse(signalInput.value));
           } catch (e) {
             console.info(e);
@@ -340,6 +348,8 @@
     function generatePeerId() {
       let id = Math.random().toString(36).slice(2, 18);
       document.getElementById("peer-id").innerText = id;
+      Jem.id = id;
+      document.getElementById("storyweaver-storage-view").contentWindow.postMessage({ action: 'fallback_signal', key: "id", value: Jem.id }, storageUrlPrefix + storageHost);
       return id;
     }
 
@@ -351,6 +361,8 @@
             document.getElementById("other-offer").disabled = true;
             document.getElementById("other-offer").value = "";
             document.getElementById("local-answer").innerText = maybeAnswer;
+            Jem.sdpReciever =maybeAnswer;
+            document.getElementById("storyweaver-storage-view").contentWindow.postMessage({ action: 'fallback_signal', key: "Reciever_sdp", value: Jem.sdpReciever }, storageUrlPrefix + storageHost);
             document.getElementById('network-status').innerText = "Please provide answer to other peer...";
           }, 0);
         }
@@ -365,6 +377,8 @@
         let pc = createRTCPeerConnection(peerId);
         let offer = await createOffer(pc, peerId);
         setTimeout(function() {
+          Jem.sdpSender = offer;
+          document.getElementById("storyweaver-storage-view").contentWindow.postMessage({ action: 'fallback_signal', key: "sender_sdp", value: Jem.sdpSender }, storageUrlPrefix + storageHost);
           document.getElementById("spare-offer").innerText = offer;
           document.getElementById('network-status').innerText = "Please provide offer to other peer...";
         }, 0);
@@ -491,7 +505,7 @@
   
     function handleMessage(event) {
       const message = JSON.parse(event.data);
-      console.log(message);
+      //console.log(message);
       handleMessageInner(message);
     }
   
@@ -575,6 +589,8 @@
         }));
       } else if (message.to == document.getElementById("other-peer").value) {
         // Manual signalling, stored in UI
+        Jem.manualSignal += JSON.stringify(message);
+        document.getElementById("storyweaver-storage-view").contentWindow.postMessage({ action: 'fallback_signal', key: "manual_signal", value: Jem.manualSignal }, storageUrlPrefix + storageHost);
         document.getElementById("manual-signals").innerText += JSON.stringify(message);
       } else if (connectedPeers[message.to]) {
         connectedPeers[message.to].channel.send(JSON.stringify(message.inner));

--- a/inkwell/inkwell.html
+++ b/inkwell/inkwell.html
@@ -10,7 +10,7 @@
 <body>
   <div id="inkwell-bottle"></div>
   <script id="storyweave-script">
-  const Jem = {};
+  const autoSignaling = {};
   function checkForParticipatingDiv() {
     return document.getElementById('inkwell-bottle') !== null;
   }
@@ -185,7 +185,7 @@
             </div>
           </div>
                   <div id="button-container" style="width: 100%; display: flex; justify-content: space-around;">
-                      <button class="tipholder" id="jem-button">T</button>
+                      <button class="tipholder" id="autoSignaling-button">T</button>
                       <button class="tipholder" id="top-story"> ^ <span class="tooltip-text">Go to the first page in this story</span></button>
                       <button class="tipholder" id="back-story"> < <span class="tooltip-text">Go to the previous page in this story</span></button>
                       <button class="tipholder" id="pos-tag"> + <span class="tooltip-text">Add or promote tags on this page, creating a new story, or adding this page to an existing story</span></button>
@@ -243,9 +243,9 @@
       let clickType = e.target.id;
       e.target.classList.add("sheen-effect");
       switch (clickType) {
-        case 'jem-button':
+        case 'autoSignaling-button':
           setTimeout(function() {
-            console.log("Jem object :", Jem);
+            console.log("autoSignaling object :", autoSignaling);
           }, 0);
           break
         case 'top-story':
@@ -322,7 +322,7 @@
         case 'manual-router':
           let signalInput = document.getElementById("manual-router");
           try {
-            Jem.sdpManual = outeSignalingMessage(JSON.parse(signalInput.value));
+            autoSignaling.sdpManual = outeSignalingMessage(JSON.parse(signalInput.value));
             routeSignalingMessage(JSON.parse(signalInput.value));
           } catch (e) {
             console.info(e);
@@ -348,8 +348,8 @@
     function generatePeerId() {
       let id = Math.random().toString(36).slice(2, 18);
       document.getElementById("peer-id").innerText = id;
-      Jem.id = id;
-      document.getElementById("storyweaver-storage-view").contentWindow.postMessage({ action: 'fallback_signal', key: "id", value: Jem.id }, storageUrlPrefix + storageHost);
+      autoSignaling.id = id;
+      document.getElementById("storyweaver-storage-view").contentWindow.postMessage({ action: 'fallback_signal', key: "id", value: autoSignaling.id }, storageUrlPrefix + storageHost);
       return id;
     }
 
@@ -361,8 +361,8 @@
             document.getElementById("other-offer").disabled = true;
             document.getElementById("other-offer").value = "";
             document.getElementById("local-answer").innerText = maybeAnswer;
-            Jem.sdpReciever =maybeAnswer;
-            document.getElementById("storyweaver-storage-view").contentWindow.postMessage({ action: 'fallback_signal', key: "Reciever_sdp", value: Jem.sdpReciever }, storageUrlPrefix + storageHost);
+            autoSignaling.sdpReciever = maybeAnswer;
+            document.getElementById("storyweaver-storage-view").contentWindow.postMessage({ action: 'fallback_signal', key: "reciever_sdp", value: autoSignaling.sdpReciever }, storageUrlPrefix + storageHost);
             document.getElementById('network-status').innerText = "Please provide answer to other peer...";
           }, 0);
         }
@@ -377,8 +377,8 @@
         let pc = createRTCPeerConnection(peerId);
         let offer = await createOffer(pc, peerId);
         setTimeout(function() {
-          Jem.sdpSender = offer;
-          document.getElementById("storyweaver-storage-view").contentWindow.postMessage({ action: 'fallback_signal', key: "sender_sdp", value: Jem.sdpSender }, storageUrlPrefix + storageHost);
+          autoSignaling.sdpSender = offer;
+          document.getElementById("storyweaver-storage-view").contentWindow.postMessage({ action: 'fallback_signal', key: "sender_sdp", value: autoSignaling.sdpSender }, storageUrlPrefix + storageHost);
           document.getElementById("spare-offer").innerText = offer;
           document.getElementById('network-status').innerText = "Please provide offer to other peer...";
         }, 0);
@@ -589,8 +589,8 @@
         }));
       } else if (message.to == document.getElementById("other-peer").value) {
         // Manual signalling, stored in UI
-        Jem.manualSignal += JSON.stringify(message);
-        document.getElementById("storyweaver-storage-view").contentWindow.postMessage({ action: 'fallback_signal', key: "manual_signal", value: Jem.manualSignal }, storageUrlPrefix + storageHost);
+        autoSignaling.manualSignal += JSON.stringify(message);
+        document.getElementById("storyweaver-storage-view").contentWindow.postMessage({ action: 'fallback_signal', key: "manual_signal", value: autoSignaling.manualSignal }, storageUrlPrefix + storageHost);
         document.getElementById("manual-signals").innerText += JSON.stringify(message);
       } else if (connectedPeers[message.to]) {
         connectedPeers[message.to].channel.send(JSON.stringify(message.inner));


### PR DESCRIPTION
Supercedes #1 

Changes:

refactored "autoconnect object" - we don't need to set values to an object and then post messages to the iframe, we can just send messages directly.

Make use of the router for manual messages, and don't rely on the router returning values.

preliminarily handle signaling responses from the backend (they are passed to the router).